### PR TITLE
Initial attempt at chaining call expressions

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -317,7 +317,7 @@ function printTrailingComment(commentPath, print) {
   //     }
   // }
 
-  parts.push(print(commentPath));
+  parts.push(print(commentPath), hardline);
 
   return concat(parts);
 }

--- a/src/printer.js
+++ b/src/printer.js
@@ -650,7 +650,8 @@ function genericPrintNoParens(path, options, print) {
       const isChain = nodes.filter(n => {
         return n.call.arguments.length > 0 &&
           (n.call.arguments[0].type === "FunctionExpression" ||
-           n.call.arguments[0].type === "ArrowFunctionExpression");
+           n.call.arguments[0].type === "ArrowFunctionExpression" ||
+           n.call.arguments[0].type === "NewExpression");
       }).length > 1;
 
       if(hasMultipleLookups) {

--- a/tests/node_tests/stream/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/node_tests/stream/__snapshots__/jsfmt.spec.js.snap
@@ -67,8 +67,9 @@ class MyWriteStream extends stream.Writable {}
 class MyDuplex extends stream.Duplex {}
 class MyTransform extends stream.Duplex {}
 
-new MyReadStream().pipe(
-  new MyDuplex()
-).pipe(new MyTransform()).pipe(new MyWriteStream());
+new MyReadStream()
+.pipe(new MyDuplex())
+.pipe(new MyTransform())
+.pipe(new MyWriteStream());
 "
 `;

--- a/tests/node_tests/stream/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/node_tests/stream/__snapshots__/jsfmt.spec.js.snap
@@ -68,8 +68,8 @@ class MyDuplex extends stream.Duplex {}
 class MyTransform extends stream.Duplex {}
 
 new MyReadStream()
-.pipe(new MyDuplex())
-.pipe(new MyTransform())
-.pipe(new MyWriteStream());
+  .pipe(new MyDuplex())
+  .pipe(new MyTransform())
+  .pipe(new MyWriteStream());
 "
 `;

--- a/tests/promises/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/promises/__snapshots__/jsfmt.spec.js.snap
@@ -529,59 +529,83 @@ Promise.reject(Promise.resolve(0)).then(function(num) {
   var b: number = num;
 });
 
-Promise.resolve(0).then(function(num) {
-  return \"asdf\";
-}).then(function(str) {
-  var a: string = str;
-  var b: number = str;
-});
+Promise
+  .resolve(0)
+  .then(function(num) {
+    return \"asdf\";
+  })
+  .then(function(str) {
+    var a: string = str;
+    var b: number = str;
+  });
 
-Promise.resolve(0).then(function(num) {
-  return Promise.resolve(\"asdf\");
-}).then(function(str) {
-  var a: string = str;
-  var b: number = str;
-});
+Promise
+  .resolve(0)
+  .then(function(num) {
+    return Promise.resolve(\"asdf\");
+  })
+  .then(function(str) {
+    var a: string = str;
+    var b: number = str;
+  });
 
-Promise.resolve(0).then(function(num) {
-  return Promise.resolve(Promise.resolve(\"asdf\"));
-}).then(function(str) {
-  var a: string = str;
-  var b: number = str;
-});
+Promise
+  .resolve(0)
+  .then(function(num) {
+    return Promise.resolve(Promise.resolve(\"asdf\"));
+  })
+  .then(function(str) {
+    var a: string = str;
+    var b: number = str;
+  });
 
-Promise.resolve(0).then(function(num) {
-  throw \"str\";
-}).catch(function(str) {
-  var a: string = str;
-  var b: number = str;
-});
+Promise
+  .resolve(0)
+  .then(function(num) {
+    throw \"str\";
+  })
+  .catch(function(str) {
+    var a: string = str;
+    var b: number = str;
+  });
 
-Promise.reject(0).catch(function(num) {
-  return \"asdf\";
-}).then(function(str) {
-  var a: string = str;
-  var b: number = str;
-});
+Promise
+  .reject(0)
+  .catch(function(num) {
+    return \"asdf\";
+  })
+  .then(function(str) {
+    var a: string = str;
+    var b: number = str;
+  });
 
-Promise.reject(0).catch(function(num) {
-  return Promise.resolve(\"asdf\");
-}).then(function(str) {
-  var a: string = str;
-  var b: number = str;
-});
+Promise
+  .reject(0)
+  .catch(function(num) {
+    return Promise.resolve(\"asdf\");
+  })
+  .then(function(str) {
+    var a: string = str;
+    var b: number = str;
+  });
 
-Promise.reject(0).catch(function(num) {
-  return Promise.resolve(Promise.resolve(\"asdf\"));
-}).then(function(str) {
-  var a: string = str;
-  var b: number = str;
-});
+Promise
+  .reject(0)
+  .catch(function(num) {
+    return Promise.resolve(Promise.resolve(\"asdf\"));
+  })
+  .then(function(str) {
+    var a: string = str;
+    var b: number = str;
+  });
 
-Promise.resolve(0).catch(function(err) {}).then(function(num) {
-  var a: number = num;
-  var b: string = num;
-});
+Promise
+  .resolve(0)
+  .catch(function(err) {})
+  .then(function(num) {
+    var a: number = num;
+    var b: string = num;
+  });
 "
 `;
 

--- a/tests/union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/union/__snapshots__/jsfmt.spec.js.snap
@@ -86,11 +86,13 @@ exports[`test issue-198.js 1`] = `
 // This should fail because str is string, not number
 var p = new Promise(function(resolve, reject) {
   resolve(5);
-}).then(function(num) {
-  return num.toFixed();
-}).then(function(str) {
-  return str.toFixed();
-});
+})
+  .then(function(num) {
+    return num.toFixed();
+  })
+  .then(function(str) {
+    return str.toFixed();
+  });
 "
 `;
 


### PR DESCRIPTION
This seems to work pretty well, however this forces simple expressions that have a CallExpression on the left-hand to break on a newline:

```js
foo()
  .callMethod()
```

The question is how can we differentiate between that and places we want to chain?